### PR TITLE
Fixed version variable in sphinx conf.py file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ author = 'Liliana M. Moreno Vargas & Diego Prada Gracia'
 # The short X.Y version
 version = pyunitwizard.__version__.split('+')[0]
 # The full version, including alpha/beta/rc tags
-release = test_uibcdf_library.__version__
+release = pyunitwizard.__version__
 
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## Description
Sphinx conf.py file was fixed. The variable 'release' takes now the value `pyunitwizard.__version__`.

## Status
- [x] Ready to go