### PR TITLE
Issue #15 fixed. Bug in lists conversion from pint to openmm.unit removed.

### DIFF
--- a/pyunitwizard/forms/api_pint.py
+++ b/pyunitwizard/forms/api_pint.py
@@ -102,12 +102,16 @@ def to_openmm_unit(quantity):
     except:
         raise LibraryNotFoundError('openmm')
 
-    pint_parser = PintParserHelper.from_string(quantity.__str__())
-    tmp_quantity = pint_parser.scale
+    value = quantity.magnitude
+
+    pint_parser = PintParserHelper.from_string(quantity.units.__str__())
+    tmp_quantity = 1
     for unit_name, exponent in pint_parser.items():
         if unit_name in ['unified_atomic_mass_unit']:
             unit_name = 'amu'
         tmp_quantity *= getattr(openmm_unit, unit_name)**exponent
+
+    tmp_quantity *= value
 
     return tmp_quantity
 


### PR DESCRIPTION
There was bug in the conversion method from pint quantities to openmm.unit reported in issue #15. This bug is fixed with this PR.

Before:
The buggy strategy was converting the quantity as a string with the assistance of PintParser. Let's see an example here as pseudocode to illustrate the approach.
```ipython
>>> q = 10 * nm/ps # as Pint quantity
>>> parser = PintParser(q)
>>> for ii, jj in parser.items():
....       print(ii, jj)
nanometers 1
picoseconds -1
```
This way the algebra of units in the pint quantity had to be translated, unit by unit, to openmm.unit. The problem is that this parser does not work when there are square brackets or parenthesis in the expression. 

The bug is fixed if only the units are parsed by the pint parser. The pint units are translated to openmm.unit to be multiplied in the very last moment by the value of the original quantity.