### PR TITLE
Handle optional library configuration in parse tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test suite package for pyunitwizard."""

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -22,7 +22,7 @@ def loaded_libraries(libraries):
             for library in ['pint', 'openmm.unit', 'unyt']:
                 try:
                     puw.configure.load_library(library)
-                except Exception:
+                except (ImportError, ModuleNotFoundError):
                     continue
         if previous_default_form is not None:
             puw.configure.set_default_form(previous_default_form)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,28 @@ import pyunitwizard as puw
 
 @contextmanager
 def loaded_libraries(libraries):
-    """Temporarily load the requested libraries for a test case."""
+    """
+    Context manager to temporarily load the requested libraries for a test case.
+
+    Parameters
+    ----------
+    libraries : list of str
+        List of library names to load temporarily for the duration of the context.
+
+    Behavior
+    --------
+    - Saves the current loaded libraries, default form, and default parser.
+    - Resets the configuration and loads the specified libraries.
+    - After the context, restores the previous configuration.
+    - If no previous libraries were loaded, attempts to load a default set
+      ('pint', 'openmm.unit', 'unyt'), ignoring failures.
+
+    Exceptions
+    ----------
+    - Any exception raised by `puw.configure.load_library` when loading the requested libraries
+      will propagate unless caught internally.
+    - Exceptions when loading default libraries after the context are caught and ignored.
+    """
     previous_libraries = list(puw.configure.get_libraries_loaded())
     previous_default_form = puw.configure.get_default_form()
     previous_default_parser = puw.configure.get_default_parser()

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,30 @@
+from contextlib import contextmanager
+
+import pyunitwizard as puw
+
+
+@contextmanager
+def loaded_libraries(libraries):
+    """Temporarily load the requested libraries for a test case."""
+    previous_libraries = list(puw.configure.get_libraries_loaded())
+    previous_default_form = puw.configure.get_default_form()
+    previous_default_parser = puw.configure.get_default_parser()
+
+    puw.configure.reset()
+    puw.configure.load_library(libraries)
+    try:
+        yield
+    finally:
+        puw.configure.reset()
+        if previous_libraries:
+            puw.configure.load_library(previous_libraries)
+        else:
+            for library in ['pint', 'openmm.unit', 'unyt']:
+                try:
+                    puw.configure.load_library(library)
+                except Exception:
+                    continue
+        if previous_default_form is not None:
+            puw.configure.set_default_form(previous_default_form)
+        if previous_default_parser is not None:
+            puw.configure.set_default_parser(previous_default_parser)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,6 +2,9 @@ from pyunitwizard.parse import _parse_with_pint, parse
 import numpy as np
 import pyunitwizard as puw
 
+from .helpers import loaded_libraries
+
+
 def test_parse_with_pint_scalar():
 
     quantity = _parse_with_pint("5 meters")
@@ -48,39 +51,42 @@ def test_parse_to_string():
 
 def test_parse_to_openmm_scalar():
 
-    quantity = parse("5 meters", to_form="openmm.unit")
-    assert quantity._value == 5
-    assert str(quantity.unit) == "meter"
+    with loaded_libraries(['pint', 'openmm.unit']):
+        quantity = parse("5 meters", to_form="openmm.unit")
+        assert quantity._value == 5
+        assert str(quantity.unit) == "meter"
 
 def test_parse_to_openmm_array():
 
-    quantity = parse("[2, 5, 7] joules", to_form="openmm.unit")
-    assert np.allclose(quantity._value, np.array([2, 5, 7]))
-    assert str(quantity.unit) == "joule"
+    with loaded_libraries(['pint', 'openmm.unit']):
+        quantity = parse("[2, 5, 7] joules", to_form="openmm.unit")
+        assert np.allclose(quantity._value, np.array([2, 5, 7]))
+        assert str(quantity.unit) == "joule"
 
-    quantity = parse("(3, 2, 1) meters", to_form="openmm.unit")
-    assert np.allclose(quantity._value, np.array([3, 2, 1]))
-    assert str(quantity.unit) == "meter"
+        quantity = parse("(3, 2, 1) meters", to_form="openmm.unit")
+        assert np.allclose(quantity._value, np.array([3, 2, 1]))
+        assert str(quantity.unit) == "meter"
 
-    quantity = parse("[[2, 5, 7], [7, 8, 9]] joules", to_form="openmm.unit")
-    assert np.allclose(quantity._value, np.array([[2, 5, 7], [7, 8, 9]]))
-    assert str(quantity.unit) == "joule"
+        quantity = parse("[[2, 5, 7], [7, 8, 9]] joules", to_form="openmm.unit")
+        assert np.allclose(quantity._value, np.array([[2, 5, 7], [7, 8, 9]]))
+        assert str(quantity.unit) == "joule"
 
 
 def test_parse_to_unyt():
 
-    quantity = parse("5 meters", to_form="unyt")
-    assert quantity.value == 5
-    assert str(quantity.units) == "m"
+    with loaded_libraries(['pint', 'unyt']):
+        quantity = parse("5 meters", to_form="unyt")
+        assert quantity.value == 5
+        assert str(quantity.units) == "m"
 
-    quantity = parse("[2, 5, 7] joules", to_form="unyt")
-    assert np.allclose(quantity.value, np.array([2, 5, 7]))
-    assert str(quantity.units) == "J"
+        quantity = parse("[2, 5, 7] joules", to_form="unyt")
+        assert np.allclose(quantity.value, np.array([2, 5, 7]))
+        assert str(quantity.units) == "J"
 
-    quantity = parse("(3, 2, 1) meters", to_form="unyt")
-    assert np.allclose(quantity.value, np.array([3, 2, 1]))
-    assert str(quantity.units) == "m"
+        quantity = parse("(3, 2, 1) meters", to_form="unyt")
+        assert np.allclose(quantity.value, np.array([3, 2, 1]))
+        assert str(quantity.units) == "m"
 
-    quantity = parse("[[2, 5, 7], [7, 8, 9]] joules", to_form="unyt")
-    assert np.allclose(quantity.value, np.array([[2, 5, 7], [7, 8, 9]]))
-    assert str(quantity.units) == "J"
+        quantity = parse("[[2, 5, 7], [7, 8, 9]] joules", to_form="unyt")
+        assert np.allclose(quantity.value, np.array([[2, 5, 7], [7, 8, 9]]))
+        assert str(quantity.units) == "J"

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1,12 +1,16 @@
 import pyunitwizard as puw
 import unyt
 
+from .helpers import loaded_libraries
+
+
 def test_quantity_openmm_unit():
 
-    openmm_unit = puw.forms.api_openmm_unit.openmm_unit
-    quantity = puw.quantity('10 kilojoule/mole', form='openmm.unit')
-    q_true = 10 * openmm_unit.kilojoule/openmm_unit.mole
-    assert puw.are_close(quantity, q_true)
+    with loaded_libraries(['pint', 'openmm.unit']):
+        openmm_unit = puw.forms.api_openmm_unit.openmm_unit
+        quantity = puw.quantity('10 kilojoule/mole', form='openmm.unit')
+        q_true = 10 * openmm_unit.kilojoule/openmm_unit.mole
+        assert puw.are_close(quantity, q_true)
 
 def test_quantity_pint():
 
@@ -16,5 +20,6 @@ def test_quantity_pint():
 
 def test_quantity_unyt():
 
-    assert puw.quantity(1.0, 
-        unyt.J/unyt.s, form="unyt") == 1.0 * unyt.J/unyt.s
+    with loaded_libraries(['pint', 'unyt']):
+        assert puw.quantity(1.0,
+            unyt.J/unyt.s, form="unyt") == 1.0 * unyt.J/unyt.s


### PR DESCRIPTION
## Summary
- add a shared helper to temporarily load and restore optional backends during tests
- update parse and quantity tests to load openmm and unyt only when needed while leaving other tests unaffected
- make the tests directory a package so helper utilities can be imported consistently

## Testing
- pytest tests/test_parse.py tests/test_quantity.py

------
https://chatgpt.com/codex/tasks/task_e_68d5d9919d44832695767ee938fba288