### PR TITLE
Add Astropy units support

### DIFF
--- a/pyunitwizard/__init__.py
+++ b/pyunitwizard/__init__.py
@@ -41,3 +41,9 @@ try:
 except:
     pass
 
+try:
+    import astropy.units  # noqa: F401
+    configure.load_library('astropy.units')
+except:
+    pass
+

--- a/pyunitwizard/_private/forms.py
+++ b/pyunitwizard/_private/forms.py
@@ -1,6 +1,6 @@
 from pyunitwizard import kernel
 
-forms = ['openmm.unit', 'pint', 'unyt', 'string']
+forms = ['openmm.unit', 'pint', 'unyt', 'astropy.units', 'string']
 
 def digest_form(form: str) -> str:
     """ Check if the form is correct. 

--- a/pyunitwizard/_private/parsers.py
+++ b/pyunitwizard/_private/parsers.py
@@ -1,4 +1,4 @@
-parsers = ['openmm.unit', 'pint', 'unyt']
+parsers = ['openmm.unit', 'pint', 'unyt', 'astropy.units']
 
 def digest_parser(parser: str) -> str:
     """ Check if parser is correct."""

--- a/pyunitwizard/configure/configure.py
+++ b/pyunitwizard/configure/configure.py
@@ -8,12 +8,14 @@ import numpy as np
 from importlib.util import find_spec
 from typing import List, Dict, Union
 
-libraries = ['pint', 'openmm.unit', 'unyt']
-parsers   = ['pint', 'openmm.unit', 'unyt']
+libraries = ['pint', 'openmm.unit', 'unyt', 'astropy.units']
+parsers   = ['pint', 'openmm.unit', 'unyt', 'astropy.units']
 _aux_dict_modules = {
-    'pint':'pint',
-    'openmm.unit':'openmm',
-    'unyt': 'unyt'}
+    'pint': 'pint',
+    'openmm.unit': 'openmm',
+    'unyt': 'unyt',
+    'astropy.units': 'astropy',
+}
 
 def reset() -> None:
     """Resets all kernel variables."""

--- a/pyunitwizard/forms/__init__.py
+++ b/pyunitwizard/forms/__init__.py
@@ -17,7 +17,12 @@ dict_dimensionality={}
 dict_compatibility={}
 
 _base_package = __name__.replace('.base','')
-_forms_apis_modules = {'openmm.unit':'api_openmm_unit', 'pint':'api_pint', 'unyt':'api_unyt'}
+_forms_apis_modules = {
+    'openmm.unit': 'api_openmm_unit',
+    'pint': 'api_pint',
+    'unyt': 'api_unyt',
+    'astropy.units': 'api_astropy_unit',
+}
 
 def load_library(library: str) -> None:
     """ Loads a library. This means that it updates all dictionaries defined above

--- a/pyunitwizard/forms/api_astropy_unit.py
+++ b/pyunitwizard/forms/api_astropy_unit.py
@@ -1,0 +1,161 @@
+from typing import Any, Dict, Union
+
+from pyunitwizard._private.exceptions import LibraryNotFoundError
+from pyunitwizard._private.quantity_or_unit import ArrayLike
+
+try:
+    from astropy import units as astropy_units
+except Exception as exc:  # pragma: no cover - handled through exception
+    raise LibraryNotFoundError('astropy') from exc
+
+AstropyQuantity = astropy_units.Quantity
+AstropyUnitBase = astropy_units.UnitBase
+
+form_name = 'astropy.units'
+parser = True
+
+is_form = {
+    AstropyQuantity: form_name,
+    AstropyUnitBase: form_name,
+}
+
+
+def _to_unit(quantity_or_unit: Union[AstropyQuantity, AstropyUnitBase]) -> AstropyUnitBase:
+    if is_quantity(quantity_or_unit):
+        return get_unit(quantity_or_unit)
+    if is_unit(quantity_or_unit):
+        return quantity_or_unit
+    raise TypeError('Expected an astropy quantity or unit')
+
+
+def is_quantity(quantity_or_unit: Any) -> bool:
+    return isinstance(quantity_or_unit, AstropyQuantity)
+
+
+def is_unit(quantity_or_unit: Any) -> bool:
+    return isinstance(quantity_or_unit, AstropyUnitBase)
+
+
+_dimensions_translator = {
+    'm': '[L]',
+    'kg': '[M]',
+    's': '[T]',
+    'K': '[K]',
+    'mol': '[mol]',
+    'A': '[A]',
+    'cd': '[Cd]',
+}
+
+
+def dimensionality(quantity_or_unit: Union[AstropyQuantity, AstropyUnitBase]) -> Dict[str, float]:
+    unit = _to_unit(quantity_or_unit)
+    decomposed = unit.decompose(bases=astropy_units.si.bases)
+    dimensionality_dict = {'[L]': 0, '[M]': 0, '[T]': 0, '[K]': 0, '[mol]': 0, '[A]': 0, '[Cd]': 0}
+
+    for base, power in zip(decomposed.bases, decomposed.powers):
+        key = _dimensions_translator.get(base.to_string())
+        if key is not None:
+            dimensionality_dict[key] += float(power)
+
+    return dimensionality_dict
+
+
+def compatibility(quantity_or_unit_1: Union[AstropyQuantity, AstropyUnitBase],
+                  quantity_or_unit_2: Union[AstropyQuantity, AstropyUnitBase]) -> bool:
+    unit_1 = _to_unit(quantity_or_unit_1)
+    unit_2 = _to_unit(quantity_or_unit_2)
+    return unit_1.is_equivalent(unit_2)
+
+
+def make_quantity(value: Union[int, float, ArrayLike],
+                  unit: Union[str, AstropyUnitBase]) -> AstropyQuantity:
+    unit_obj = astropy_units.Unit(unit)
+    return astropy_units.Quantity(value, unit_obj)
+
+
+def get_value(quantity: AstropyQuantity) -> Union[int, float, ArrayLike]:
+    return quantity.value
+
+
+def get_unit(quantity: AstropyQuantity) -> AstropyUnitBase:
+    return quantity.unit
+
+
+def change_value(quantity: AstropyQuantity,
+                 value: Union[int, float, ArrayLike]) -> AstropyQuantity:
+    return make_quantity(value, get_unit(quantity))
+
+
+def convert(quantity: AstropyQuantity,
+            unit: Union[str, AstropyUnitBase]) -> AstropyQuantity:
+    unit_obj = astropy_units.Unit(unit)
+    return quantity.to(unit_obj)
+
+
+# Parser
+
+def string_to_quantity(string: str) -> AstropyQuantity:
+    return astropy_units.Quantity(string)
+
+
+def string_to_unit(string: str) -> AstropyUnitBase:
+    return astropy_units.Unit(string)
+
+
+# To string
+
+def quantity_to_string(quantity: AstropyQuantity) -> str:
+    return str(quantity)
+
+
+def unit_to_string(unit: AstropyUnitBase) -> str:
+    return unit.to_string()
+
+
+# To pint
+
+def quantity_to_pint(quantity: AstropyQuantity):
+    from .api_pint import make_quantity as make_pint_quantity
+
+    value = get_value(quantity)
+    unit_name = unit_to_string(get_unit(quantity))
+    return make_pint_quantity(value, unit_name)
+
+
+def unit_to_pint(unit: AstropyUnitBase):
+    from .api_pint import get_unit as get_pint_unit
+
+    quantity = quantity_to_pint(1.0 * unit)
+    return get_pint_unit(quantity)
+
+
+# To openmm.unit
+
+def quantity_to_openmm_unit(quantity: AstropyQuantity):
+    from .api_pint import quantity_to_openmm_unit as pint_to_openmm_unit
+
+    pint_quantity = quantity_to_pint(quantity)
+    return pint_to_openmm_unit(pint_quantity)
+
+
+def unit_to_openmm_unit(unit: AstropyUnitBase):
+    from .api_openmm_unit import get_unit as get_openmm_unit
+
+    quantity = quantity_to_openmm_unit(1.0 * unit)
+    return get_openmm_unit(quantity)
+
+
+# To unyt
+
+def quantity_to_unyt(quantity: AstropyQuantity):
+    from .api_pint import quantity_to_unyt as pint_to_unyt
+
+    pint_quantity = quantity_to_pint(quantity)
+    return pint_to_unyt(pint_quantity)
+
+
+def unit_to_unyt(unit: AstropyUnitBase):
+    from .api_unyt import get_unit as get_unyt_unit
+
+    quantity = quantity_to_unyt(1.0 * unit)
+    return get_unyt_unit(quantity)

--- a/pyunitwizard/forms/api_openmm_unit.py
+++ b/pyunitwizard/forms/api_openmm_unit.py
@@ -306,12 +306,12 @@ def quantity_to_unyt(quantity: openmm_unit.Quantity):
 
 def unit_to_unyt(unit: openmm_unit.Unit):
     """ Transform a unit from openmm.unit to a unyt unit.
-        
+
         Parameters
         -----------
         unit : openmm.unit.Unit
             A unit.
-        
+
         Returns
         -------
         unyt_unit
@@ -322,4 +322,26 @@ def unit_to_unyt(unit: openmm_unit.Unit):
     quantity = quantity_to_unyt(1.0*unit)
 
     return get_unyt_unit(quantity)
+
+
+## To astropy.units
+
+def quantity_to_astropy_units(quantity: openmm_unit.Quantity):
+    """ Transform a quantity from openmm.unit to astropy.units."""
+
+    from .api_pint import quantity_to_astropy_units as pint_to_astropy_units
+
+    pint_quantity = quantity_to_pint(quantity)
+
+    return pint_to_astropy_units(pint_quantity)
+
+
+def unit_to_astropy_units(unit: openmm_unit.Unit):
+    """ Transform a unit from openmm.unit to astropy.units."""
+
+    from .api_astropy_unit import get_unit as get_astropy_unit
+
+    quantity = quantity_to_astropy_units(1.0*unit)
+
+    return get_astropy_unit(quantity)
 

--- a/pyunitwizard/forms/api_pint.py
+++ b/pyunitwizard/forms/api_pint.py
@@ -331,12 +331,12 @@ def quantity_to_unyt(quantity: pint.Quantity):
 
 def unit_to_unyt(unit: pint.Unit):
     """ Transform a unit from a pint unit to a unyt unit.
-        
+
         Parameters
         -----------
         unit : pint.Unit
             A unit.
-        
+
         Returns
         -------
         unyt_array or unyt_quantity
@@ -348,5 +348,28 @@ def unit_to_unyt(unit: pint.Unit):
     quantity = quantity_to_unyt(1.0*unit)
 
     return get_unyt_unit(quantity)
+
+
+## To astropy.units
+
+def quantity_to_astropy_units(quantity: pint.Quantity):
+    """ Transform a quantity from pint to astropy.units."""
+
+    from .api_astropy_unit import make_quantity as make_astropy_quantity
+
+    value = get_value(quantity)
+    unit_name = unit_to_string(get_unit(quantity))
+
+    return make_astropy_quantity(value, unit_name)
+
+
+def unit_to_astropy_units(unit: pint.Unit):
+    """ Transform a unit from pint to astropy.units."""
+
+    from .api_astropy_unit import get_unit as get_astropy_unit
+
+    quantity = quantity_to_astropy_units(1.0*unit)
+
+    return get_astropy_unit(quantity)
 
 

--- a/pyunitwizard/forms/api_string.py
+++ b/pyunitwizard/forms/api_string.py
@@ -234,12 +234,12 @@ def quantity_to_pint(quantity: str):
 
 def unit_to_pint(unit: str):
     """ Transform a quantity from a string quantity to a pint quantity.
-        
+
         Parameters
         -----------
         quantity : str
             A quanitity.
-        
+
         Returns
         -------
         pint.Quantity
@@ -259,4 +259,20 @@ def quantity_to_unyt(quantity: str):
 
 def unit_to_unyt(quantity: str):
     raise NotImplementedError
+
+
+## To astropy.units
+
+def quantity_to_astropy_units(quantity: str):
+    from .api_astropy_unit import string_to_quantity as _string_to_quantity
+
+    return _string_to_quantity(quantity)
+
+
+def unit_to_astropy_units(unit: str):
+    from .api_astropy_unit import get_unit as get_astropy_unit
+
+    quantity = quantity_to_astropy_units(unit)
+
+    return get_astropy_unit(quantity)
 

--- a/pyunitwizard/forms/api_unyt.py
+++ b/pyunitwizard/forms/api_unyt.py
@@ -295,12 +295,12 @@ def quantity_to_openmm_unit(quantity: Union[unyt_array, unyt_quantity]):
 
 def unit_to_openmm_unit(unit: unyt_unit):
     """ Transform a unit from unyt to a openmm.unit unit.
-        
+
         Parameters
         -----------
         unit : unyt_unit
             A unit.
-        
+
         Returns
         -------
         openmm_unit.Unit
@@ -311,5 +311,27 @@ def unit_to_openmm_unit(unit: unyt_unit):
     quantity = quantity_to_openmm_unit(1.0*unit)
 
     return get_openmm_unit_unit(quantity)
+
+
+## To astropy.units
+
+def quantity_to_astropy_units(quantity: Union[unyt_array, unyt_quantity]):
+    """ Transform a quantity from unyt to astropy.units."""
+
+    from .api_pint import quantity_to_astropy_units as pint_to_astropy_units
+
+    pint_quantity = quantity.to_pint()
+
+    return pint_to_astropy_units(pint_quantity)
+
+
+def unit_to_astropy_units(unit: unyt_unit):
+    """ Transform a unit from unyt to astropy.units."""
+
+    from .api_astropy_unit import get_unit as get_astropy_unit
+
+    quantity = quantity_to_astropy_units(1.0*unit)
+
+    return get_astropy_unit(quantity)
 
 

--- a/pyunitwizard/main.py
+++ b/pyunitwizard/main.py
@@ -40,7 +40,7 @@ def is_quantity(quantity_or_unit: QuantityOrUnit, parser: Optional[str]=None) ->
         quantity_or_unit : QuantityOrUnit
             A quanitity or a unit
 
-        parser :  {"unyt", "pint", "openmm.unit"}, optional
+        parser :  {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser for string quantities
 
         Returns
@@ -71,7 +71,7 @@ def is_unit(quantity_or_unit: QuantityOrUnit, parser: Optional[str]=None) -> boo
         quantity_or_unit : QuantityOrUnit
             A quantity or a unit
 
-        parser :  {"unyt", "pint", "openmm.unit"}, optional
+        parser :  {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser for string quantities
 
         Returns
@@ -105,7 +105,7 @@ def get_value(quantity: QuantityLike,
         to_unit : str, optional
             Name of the unit to which the quantity will be converted (i.e kcal/mol).
         
-        parser : {"unyt", "pint", "openmm.unit"}, optional
+        parser : {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser to use.
 
         Returns
@@ -132,10 +132,10 @@ def get_unit(quantity: QuantityLike,
         to_unit : str, optional
             Name of the unit to which the quantity will be converted (i.e kcal/mol).
         
-         form : {"unyt", "pint", "openmm.unit", "string"}, optional
+         form : {"unyt", "pint", "openmm.unit", "astropy.units", "string"}, optional
             If passed the unit will be converted to that form. This is the type that will be returned
 
-        parser : {"unyt", "pint", "openmm.unit"}, optional
+        parser : {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser to use.
 
         Returns
@@ -162,7 +162,7 @@ def get_value_and_unit(quantity: QuantityLike,
         to_unit : str, optional
             Name of the unit to which the quantity will be converted (i.e kcal/mol).
         
-        parser : {"unyt", "pint", "openmm.unit"}, optional
+        parser : {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser to use.
 
         Returns
@@ -456,10 +456,10 @@ def quantity(value: Union[int, float, ArrayLike],
         unit : UnitLike
             Unit in of the quantity in any of the accepted form.
 
-        form : {"unyt", "pint", "openmm.unit", "string"}, optional
+        form : {"unyt", "pint", "openmm.unit", "astropy.units", "string"}, optional
             Output form of the quantity.
 
-        parser : {"unyt", "pint", "openmm.unit"}, optional
+        parser : {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser to use.
 
         standardized : bool, optional
@@ -508,10 +508,10 @@ def unit(unit: str, form: Optional[str]=None, parser: Optional[str]=None) -> Uni
         unit : str
             Name of the unit (i.e kcal/mol).
         
-        form : {"unyt", "pint", "openmm.unit", "string"}, optional
+        form : {"unyt", "pint", "openmm.unit", "astropy.units", "string"}, optional
             The form of the unit. This is the type that will be returned
         
-        parser : {"unyt", "pint", "openmm.unit"}, optional
+        parser : {"unyt", "pint", "openmm.unit", "astropy.units"}, optional
             The parser to use.
         
         Returns
@@ -535,10 +535,10 @@ def convert(quantity_or_unit: Any,
         to_unit : str, optional
             The unit to convert to.
         
-        to_form : {"unyt", "pint", "openmm.unit", "string"}, optional
+        to_form : {"unyt", "pint", "openmm.unit", "astropy.units", "string"}, optional
             The form to convert to.
         
-        parser : {"pint", "openmm.unit"}, optional
+        parser : {"pint", "openmm.unit", "astropy.units"}, optional
             The parser to use if a string is passed.
         
         to_type : {"quantity", "unit", "value"}, optional

--- a/pyunitwizard/parse.py
+++ b/pyunitwizard/parse.py
@@ -72,8 +72,8 @@ def parse(string: str, parser: Optional[str]=None, to_form: Optional[str]=None):
             The parser that will be used.
 
         to_form; str, optional
-            The form of the quantity. Can be pint, openmm.unit or
-            string.
+            The form of the quantity. Can be "pint", "openmm.unit",
+            "unyt", "astropy.units" or "string".
 
         Returns
         -------
@@ -97,17 +97,36 @@ def parse(string: str, parser: Optional[str]=None, to_form: Optional[str]=None):
         elif to_form == 'string':
             pint_quantity = _parse_with_pint(string)
             return dict_translate_quantity['pint']['string'](pint_quantity)
-        
+
         elif to_form == 'unyt':
             pint_quantity = _parse_with_pint(string)
             return dict_translate_quantity['pint']['unyt'](pint_quantity)
 
+        elif to_form == 'astropy.units':
+            pint_quantity = _parse_with_pint(string)
+            return dict_translate_quantity['pint']['astropy.units'](pint_quantity)
+
         else:
-            raise NotImplementedParsingError(parser, to_form)
+            raise NotImplementedParserError(parser, to_form)
 
     elif parser == 'openmm.unit':
         raise LibraryWithoutParserError('openmm.unit')
     elif parser == 'unyt':
         raise LibraryWithoutParserError("unyt")
+    elif parser == 'astropy.units':
+        astropy_quantity = dict_translate_quantity['string']['astropy.units'](string)
+
+        if to_form == 'astropy.units':
+            return astropy_quantity
+        elif to_form == 'pint':
+            return dict_translate_quantity['astropy.units']['pint'](astropy_quantity)
+        elif to_form == 'string':
+            return dict_translate_quantity['astropy.units']['string'](astropy_quantity)
+        elif to_form == 'openmm.unit':
+            return dict_translate_quantity['astropy.units']['openmm.unit'](astropy_quantity)
+        elif to_form == 'unyt':
+            return dict_translate_quantity['astropy.units']['unyt'](astropy_quantity)
+        else:
+            raise NotImplementedParserError(parser, to_form)
     else:
-        raise NotImplementedParsingError(parser, to_form)
+        raise NotImplementedParserError(parser, to_form)

--- a/tests/astropy_units/test_astropy_units.py
+++ b/tests/astropy_units/test_astropy_units.py
@@ -1,0 +1,87 @@
+import pytest
+
+import pyunitwizard as puw
+
+astropy_units = pytest.importorskip("astropy.units")
+from astropy import units as u
+
+
+@pytest.fixture
+def astropy_setup():
+    loaded_before = list(puw.configure.get_libraries_loaded())
+    default_form = puw.configure.get_default_form()
+    default_parser = puw.configure.get_default_parser()
+
+    puw.configure.reset()
+    puw.configure.load_library(["pint", "astropy.units"])
+
+    yield
+
+    puw.configure.reset()
+    if loaded_before:
+        puw.configure.load_library(loaded_before)
+        if default_form is not None:
+            puw.configure.set_default_form(default_form)
+        if default_parser is not None:
+            puw.configure.set_default_parser(default_parser)
+
+
+def test_get_form_astropy_quantity(astropy_setup):
+    quantity = 5.0 * u.m
+    assert puw.get_form(quantity) == "astropy.units"
+
+
+def test_is_quantity_and_unit(astropy_setup):
+    quantity = 3.0 * u.s
+    assert puw.is_quantity(quantity)
+    assert puw.is_unit(quantity.unit)
+
+
+def test_convert_within_astropy(astropy_setup):
+    quantity = 2.0 * u.m
+    converted = puw.convert(quantity, to_unit="cm")
+    assert puw.get_form(converted) == "astropy.units"
+    assert puw.get_value(converted) == pytest.approx(200.0)
+
+
+def test_convert_to_pint(astropy_setup):
+    quantity = 7.0 * u.kg
+    pint_quantity = puw.convert(quantity, to_form="pint")
+    pytest.importorskip("pint")
+    from pint import Quantity as PintQuantity
+
+    assert isinstance(pint_quantity, PintQuantity)
+    assert pint_quantity.magnitude == pytest.approx(7.0)
+    assert str(pint_quantity.units) == "kilogram"
+
+
+def test_dimensionality(astropy_setup):
+    quantity = 3.0 * u.m / u.s
+    dims = puw.get_dimensionality(quantity)
+    assert dims["[L]"] == pytest.approx(1.0)
+    assert dims["[T]"] == pytest.approx(-1.0)
+
+
+def test_compatibility(astropy_setup):
+    assert puw.are_compatible(u.m, u.cm)
+
+
+def test_string_parser(astropy_setup):
+    quantity = puw.convert("10 m", to_form="astropy.units", parser="astropy.units")
+    assert puw.is_quantity(quantity)
+    assert puw.get_value(quantity) == pytest.approx(10.0)
+    assert puw.get_form(quantity) == "astropy.units"
+
+
+def test_quantity_constructor(astropy_setup):
+    quantity = puw.quantity(1.5, unit=u.km, form="astropy.units")
+    assert puw.is_quantity(quantity)
+    assert puw.get_unit(quantity).is_equivalent(u.m)
+    assert puw.get_value(puw.convert(quantity, to_unit="m")) == pytest.approx(1500.0)
+
+
+def test_to_string_conversion(astropy_setup):
+    quantity = 1.2 * u.m
+    string_quantity = puw.to_string(quantity, to_unit="cm")
+    assert "120" in string_quantity
+    assert "cm" in string_quantity

--- a/tests/test_configure.py
+++ b/tests/test_configure.py
@@ -1,7 +1,7 @@
 import pyunitwizard as puw
 
 def test_libraries_supported():
-    assert puw.configure.get_libraries_supported()==['pint', 'openmm.unit', 'unyt']
+    assert puw.configure.get_libraries_supported()==['pint', 'openmm.unit', 'unyt', 'astropy.units']
 
 def test_load_library():
     puw.configure.reset()
@@ -29,6 +29,12 @@ def test_init_openmolecularsystems():
 
 def test_all():
     puw.configure.reset()
-    puw.configure.load_library(['pint', 'openmm.unit', 'unyt'])
+    libraries = ['pint', 'openmm.unit', 'unyt']
+    try:
+        import astropy.units  # noqa: F401
+    except Exception:
+        puw.configure.load_library(libraries)
+    else:
+        puw.configure.load_library(libraries + ['astropy.units'])
 
     assert True


### PR DESCRIPTION
## Summary
- add an `astropy.units` form implementation with conversions, dimensionality, and parser support
- register the Astropy form across configuration, parser dispatch, and string translation helpers
- cover the new form with Astropy-focused tests and update configuration expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5c8acfc4c8326b42a74f902bee1d0