### PR TITLE
Add comprehensive PyUnitWizard showcase notebook

### DIFF
--- a/docs/contents/showcase/PyUnitWizard_Showcase.ipynb
+++ b/docs/contents/showcase/PyUnitWizard_Showcase.ipynb
@@ -1,0 +1,771 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "e731f46f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:04.349419Z",
+     "iopub.status.busy": "2025-09-26T18:07:04.349236Z",
+     "iopub.status.idle": "2025-09-26T18:07:04.421852Z",
+     "shell.execute_reply": "2025-09-26T18:07:04.421260Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33e55d44",
+   "metadata": {},
+   "source": [
+    "# PyUnitWizard Showcase: A Cross-Library Tour\n",
+    "\n",
+    "Welcome to the PyUnitWizard showcase! This notebook walks you through the essentials of the library so you can work comfortably with physical quantities across different Python unit systems. Whether you prefer Pint, OpenMM units, unyt, or Astropy units, PyUnitWizard gives you a single API to inspect, convert, and compare them."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b05d5416",
+   "metadata": {},
+   "source": [
+    "## What you will learn\n",
+    "\n",
+    "* How to configure PyUnitWizard for the unit libraries you already use.\n",
+    "* How to create and inspect quantities in the default unit system.\n",
+    "* How to convert values, units, and whole quantities across forms.\n",
+    "* How to keep calculations consistent with dimensional analysis and standardized units.\n",
+    "* How to work with NumPy arrays, parse textual quantities, and access built-in constants."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26c3ddf9",
+   "metadata": {},
+   "source": [
+    "## Before you start\n",
+    "\n",
+    "PyUnitWizard itself is lightweight, but you will want to install the unit libraries you plan to interoperate with. A typical environment created with `pip` may look like:\n",
+    "\n",
+    "```bash\n",
+    "pip install pyunitwizard pint openmm unyt astropy\n",
+    "```\n",
+    "\n",
+    "Once the packages are available, we can import PyUnitWizard and NumPy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "28d94bc0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:04.424706Z",
+     "iopub.status.busy": "2025-09-26T18:07:04.424535Z",
+     "iopub.status.idle": "2025-09-26T18:07:05.970494Z",
+     "shell.execute_reply": "2025-09-26T18:07:05.969858Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pyunitwizard as puw\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f50472d9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:05.973191Z",
+     "iopub.status.busy": "2025-09-26T18:07:05.973012Z",
+     "iopub.status.idle": "2025-09-26T18:07:05.990127Z",
+     "shell.execute_reply": "2025-09-26T18:07:05.989645Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PyUnitWizard version 1.0.0+288.g4be236b\n"
+     ]
+    }
+   ],
+   "source": [
+    "puw.__print_version__()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7cbb77d",
+   "metadata": {},
+   "source": [
+    "## Loading libraries and setting defaults\n",
+    "\n",
+    "PyUnitWizard can talk to several backends, but it only enables what you load explicitly. The `configure` module lets you explore what is supported and make the choices that fit your project."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "803aff98",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:05.992543Z",
+     "iopub.status.busy": "2025-09-26T18:07:05.992327Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.004635Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.003969Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Supported libraries: ['pint', 'openmm.unit', 'unyt', 'astropy.units']\n",
+      "Supported parsers: ['pint', 'openmm.unit', 'unyt', 'astropy.units']\n"
+     ]
+    }
+   ],
+   "source": [
+    "supported_libs = puw.configure.get_libraries_supported()\n",
+    "supported_parsers = puw.configure.get_parsers_supported()\n",
+    "print('Supported libraries:', supported_libs)\n",
+    "print('Supported parsers:', supported_parsers)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "e55e4052",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.006988Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.006806Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.019696Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.018950Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded libraries: ['pint', 'openmm.unit', 'unyt', 'astropy.units']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Start from a clean slate for reproducibility in this notebook\n",
+    "puw.configure.reset()\n",
+    "\n",
+    "# Load all available libraries so we can demonstrate conversions among them\n",
+    "puw.configure.load_library(['pint', 'openmm.unit', 'unyt', 'astropy.units'])\n",
+    "\n",
+    "print('Loaded libraries:', puw.configure.get_libraries_loaded())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "0dc05a8e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.021994Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.021817Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.036815Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.036234Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Default form: pint\n",
+      "Default parser: pint\n",
+      "Standards: {'nanometer': {'[L]': 1, '[M]': 0, '[T]': 0, '[K]': 0, '[mol]': 0, '[A]': 0, '[Cd]': 0}, 'picosecond': {'[L]': 0, '[M]': 0, '[T]': 1, '[K]': 0, '[mol]': 0, '[A]': 0, '[Cd]': 0}, 'kcal/mol': {'[L]': 2, '[M]': 1, '[T]': -2, '[K]': 0, '[mol]': -1, '[A]': 0, '[Cd]': 0}, 'kelvin': {'[L]': 0, '[M]': 0, '[T]': 0, '[K]': 1, '[mol]': 0, '[A]': 0, '[Cd]': 0}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Choose Pint as the default form for new quantities\n",
+    "puw.configure.set_default_form('pint')\n",
+    "puw.configure.set_default_parser('pint')\n",
+    "\n",
+    "# Pick a consistent set of standard units for later comparisons\n",
+    "puw.configure.set_standard_units(['nanometer', 'picosecond', 'kcal/mol', 'kelvin'])\n",
+    "\n",
+    "print('Default form:', puw.configure.get_default_form())\n",
+    "print('Default parser:', puw.configure.get_default_parser())\n",
+    "print('Standards:', puw.configure.get_standard_units())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b29e0815",
+   "metadata": {},
+   "source": [
+    "## Creating and inspecting quantities\n",
+    "\n",
+    "The `quantity` constructor produces an object in the default form (Pint in our configuration). PyUnitWizard keeps track of both value and unit metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "056e992e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.038816Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.038636Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.051734Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.051216Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.5 nanometer\n",
+      "Form: pint\n",
+      "Value: 2.5\n",
+      "Unit: nanometer\n"
+     ]
+    }
+   ],
+   "source": [
+    "distance = puw.quantity(2.5, 'nanometers')\n",
+    "print(distance)\n",
+    "print('Form:', puw.get_form(distance))\n",
+    "print('Value:', puw.get_value(distance))\n",
+    "print('Unit:', puw.get_unit(distance))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d84b0ac2",
+   "metadata": {},
+   "source": [
+    "You can obtain the value and unit separately in different forms. For instance, converting the value to ångströms while requesting the unit in OpenMM notation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ee51124c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.053817Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.053631Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.067086Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.066496Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Value in Å: 25.0\n",
+      "Unit in OpenMM form: angstrom\n"
+     ]
+    }
+   ],
+   "source": [
+    "value_angstrom, unit_openmm = puw.get_value_and_unit(distance, to_unit='angstrom', to_form='openmm.unit')\n",
+    "print('Value in Å:', value_angstrom)\n",
+    "print('Unit in OpenMM form:', unit_openmm)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cab6edcf",
+   "metadata": {},
+   "source": [
+    "## Converting across forms and units\n",
+    "\n",
+    "Quantities can be translated into any loaded library or expressed with different units. The `convert` helper drives both operations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0573c4a7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.069207Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.069022Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.082389Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.081785Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "As an OpenMM quantity: 2.5 nm\n",
+      "In picometers: 2500.0000000000005 picometer\n",
+      "Form after conversion: openmm.unit\n"
+     ]
+    }
+   ],
+   "source": [
+    "distance_openmm = puw.convert(distance, to_form='openmm.unit')\n",
+    "distance_picometers = puw.convert(distance, to_unit='picometer')\n",
+    "\n",
+    "print('As an OpenMM quantity:', distance_openmm)\n",
+    "print('In picometers:', distance_picometers)\n",
+    "print('Form after conversion:', puw.get_form(distance_openmm))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd59b063",
+   "metadata": {},
+   "source": [
+    "## Dimensional analysis and compatibility checks\n",
+    "\n",
+    "PyUnitWizard can read the dimensionality of a quantity and tell you whether two objects are compatible or close within tolerances."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "34b74fe1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.084450Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.084276Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.097050Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.096494Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Speed dimensionality: {'[L]': 1, '[M]': 0, '[T]': -1, '[K]': 0, '[mol]': 0, '[A]': 0, '[Cd]': 0}\n",
+      "Acceleration dimensionality: {'[L]': 1, '[M]': 0, '[T]': -2, '[K]': 0, '[mol]': 0, '[A]': 0, '[Cd]': 0}\n",
+      "Are speed and acceleration compatible? False\n"
+     ]
+    }
+   ],
+   "source": [
+    "speed = puw.quantity(5.0, 'meter/second')\n",
+    "acceleration = puw.quantity(1.2, 'meter/second**2')\n",
+    "print('Speed dimensionality:', puw.get_dimensionality(speed))\n",
+    "print('Acceleration dimensionality:', puw.get_dimensionality(acceleration))\n",
+    "print('Are speed and acceleration compatible?', puw.are_compatible(speed, acceleration))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "67b449b3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.098858Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.098700Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.111609Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.110958Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converted speed: 11.184681460272012 mile / hour\n",
+      "Are the two speed representations close? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "speed_mph = puw.convert(speed, to_unit='mile/hour')\n",
+    "print('Converted speed:', speed_mph)\n",
+    "print('Are the two speed representations close?', puw.are_close(speed, speed_mph, rtol=1e-9))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "310f5b8e",
+   "metadata": {},
+   "source": [
+    "## Working with arrays of values\n",
+    "\n",
+    "Under the hood PyUnitWizard can store NumPy arrays. This is convenient when your simulation or experiment delivers vectorized data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "51d5f7e1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.113661Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.113488Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.127310Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.126712Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Trajectory values: [0.   0.25 0.5  0.75 1.  ]\n",
+      "Converted to nanometers: [   0.  250.  500.  750. 1000.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "trajectory = puw.quantity(np.linspace(0, 1, 5), 'micrometers')\n",
+    "print('Trajectory values:', puw.get_value(trajectory))\n",
+    "print('Converted to nanometers:', puw.get_value(trajectory, to_unit='nanometer'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "72f9f8bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.129509Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.129333Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.142485Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.141865Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Standardized trajectory unit: nanometer\n",
+      "Values in standards: [   0.  250.  500.  750. 1000.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Standardize the array so it follows the project-wide conventions\n",
+    "trajectory_std = puw.standardize(trajectory)\n",
+    "print('Standardized trajectory unit:', puw.get_unit(trajectory_std))\n",
+    "print('Values in standards:', puw.get_value(trajectory_std))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64f1c3f3",
+   "metadata": {},
+   "source": [
+    "## Parsing from strings and manipulating units\n",
+    "\n",
+    "When ingesting data from configuration files or user input, quantities often arrive as strings. Use the default parser (or specify one) to turn them into rich objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "9d32d9d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.144348Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.144173Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.157420Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.156798Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parsed quantity: 42.0 kilocalorie / mole\n",
+      "Is it recognized as a quantity? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "string_quantity = puw.convert('42 kilocalorie/mole', to_form='pint')\n",
+    "print('Parsed quantity:', string_quantity)\n",
+    "print('Is it recognized as a quantity?', puw.is_quantity(string_quantity))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "c0b7074e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.159462Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.159285Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.172639Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.171834Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Unit object: kilojoule / mole / nanometer\n",
+      "Is it a unit? True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You can also inspect plain units without attaching a value\n",
+    "force_unit = puw.unit('kilojoule/(nanometer*mole)', form='pint')\n",
+    "print('Unit object:', force_unit)\n",
+    "print('Is it a unit?', puw.is_unit(force_unit))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a908fb43",
+   "metadata": {},
+   "source": [
+    "If a value needs to be updated while keeping all metadata intact, `change_value` does the job."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "87795cc2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.174646Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.174463Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.187483Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.186843Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Updated distance: 3.1 nanometer\n"
+     ]
+    }
+   ],
+   "source": [
+    "updated_distance = puw.change_value(distance, 3.1)\n",
+    "print('Updated distance:', updated_distance)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b1cfc01",
+   "metadata": {},
+   "source": [
+    "## Maintaining consistency with standards\n",
+    "\n",
+    "In collaborative settings it is common to enforce a canonical representation for reporting. `standardize` converts any compatible quantity to the configured standard units and default form."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "060700c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.189473Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.189264Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.203420Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.202846Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original energy: -12.5 kilojoule / mole\n",
+      "Standardized energy: -2.987571701720841 kilocalorie / mole\n",
+      "As a string: -2.987571701720841 kilocalorie / mole\n"
+     ]
+    }
+   ],
+   "source": [
+    "energy = puw.quantity(-12.5, 'kilojoule/mole')\n",
+    "energy_std = puw.standardize(energy)\n",
+    "print('Original energy:', energy)\n",
+    "print('Standardized energy:', energy_std)\n",
+    "print('As a string:', puw.to_string(energy_std))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0960e33a",
+   "metadata": {},
+   "source": [
+    "The `check` helper raises an informative error if a quantity does not match an expected dimensionality. It is a lightweight guard for functions that demand specific units."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6cb1cc95",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.205667Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.205490Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.218523Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.218068Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Speed passes the dimensionality check.\n"
+     ]
+    }
+   ],
+   "source": [
+    "try:\n",
+    "    puw.check(speed, dimensionality={'[L]': 1, '[T]': -1})\n",
+    "    print('Speed passes the dimensionality check.')\n",
+    "except Exception as exc:\n",
+    "    print('Check failed:', exc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "ff28274a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.220730Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.220560Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.232922Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.232401Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    puw.check(acceleration, dimensionality={'[L]': 1, '[T]': -1})\n",
+    "except Exception as exc:\n",
+    "    print('Acceleration check result:', exc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c24b9375",
+   "metadata": {},
+   "source": [
+    "## Accessing physical constants\n",
+    "\n",
+    "PyUnitWizard bundles a few frequently used physical constants. They are expressed as regular quantities, so you can convert them like any other value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "ee18ab0c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.235087Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.234917Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.247662Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.247228Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avogadro, NA -> 6.02214076e+23 1/mole\n",
+      "Universal gas, R, Molar gas -> 8.13446261815324 J/(kelvin*mole)\n",
+      "Boltzmann, KB -> 1.380649e-23 J/kelvin\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyunitwizard import constants\n",
+    "constants_catalog = constants.show_constants()\n",
+    "for names, text in constants_catalog.items():\n",
+    "    print(', '.join(names), '->', text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "28f28bf8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-09-26T18:07:06.249698Z",
+     "iopub.status.busy": "2025-09-26T18:07:06.249522Z",
+     "iopub.status.idle": "2025-09-26T18:07:06.262314Z",
+     "shell.execute_reply": "2025-09-26T18:07:06.261852Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Avogadro constant: 6.02214076e+23 / mole\n",
+      "Unit form: 1 / mole\n"
+     ]
+    }
+   ],
+   "source": [
+    "avogadro_entry = constants_catalog[('Avogadro', 'NA')]\n",
+    "avogadro = puw.convert(avogadro_entry, parser='pint')\n",
+    "print('Avogadro constant:', avogadro)\n",
+    "print('Unit form:', puw.get_unit(avogadro))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9791d7fa",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "* Configure PyUnitWizard once and reuse the same API with multiple unit toolkits.\n",
+    "* Generate quantities from numbers, arrays, or strings and interrogate their form, value, and dimensionality.\n",
+    "* Convert seamlessly across forms, enforce project-wide standards, and validate inputs with helper checks.\n",
+    "* Tap into bundled constants or extend the approach for your own domain-specific catalog.\n",
+    "\n",
+    "You now have a tour of the core features that make PyUnitWizard a flexible companion when juggling different unit systems."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/contents/showcase/index.rst
+++ b/docs/contents/showcase/index.rst
@@ -6,5 +6,6 @@ Showcase
 .. toctree::
    :maxdepth: 1
 
+   PyUnitWizard_Showcase.ipynb
    Quick_Guide.ipynb
 


### PR DESCRIPTION
## Summary
- add a showcase Jupyter notebook that walks new users through configuring, converting, and validating PyUnitWizard quantities across libraries
- register the new notebook in the Showcase table of contents

## Testing
- jupyter nbconvert --to notebook --execute --inplace docs/contents/showcase/PyUnitWizard_Showcase.ipynb

------
https://chatgpt.com/codex/tasks/task_e_68d6d31728588326954cdaa5eb0c59d3